### PR TITLE
Fix for issue with renames

### DIFF
--- a/sync_public_branch.sh
+++ b/sync_public_branch.sh
@@ -128,7 +128,7 @@ for sha1 in $(git rev-list --reverse ${LATEST_BRANCH_REF}..${WORK_BRANCH}); do
   else
     mainline_args='-m 2'
   fi
-  cherry_pick --keep-redundant-commits --allow-empty --strategy=recursive -X ours $mainline_args "$sha1"
+  cherry_pick --keep-redundant-commits --allow-empty --strategy=recursive -Xno-renames -X ours $mainline_args "$sha1"
 done
 
 if [ "$cherry_pick_failed" ]; then


### PR DESCRIPTION
This fix fixes the issue we had last night https://github.com/SonarSource/sonar-enterprise/runs/4467834247?check_suite_focus=true 

The problem here was that in private sonar-enterprise repo file was _copied_ (not moved) from private to "public" part of repository. The git when running this sync script detects this file as moved - because private folder is not part of public sonarqube repository. But in the original commit this file was not moved - it was created. And here we end in the conflict. This flag ensures we will not have conflicts like this anymore.