### PR TITLE
Update commit_sync_public_branch.sh

### DIFF
--- a/commit_sync_public_branch.sh
+++ b/commit_sync_public_branch.sh
@@ -33,17 +33,18 @@ PUBLIC_BRANCH="public_${BRANCH}"
 # to know where we are
 git checkout "${PUBLIC_BRANCH}"
 
-info "Pushing ${PUBLIC_BRANCH} to private repository and ${BRANCH} to public repository..."
+info "Pushing ${PUBLIC_BRANCH} to private repository..."
 git push "${PRIVATE_REMOTE}" "${PUBLIC_BRANCH}:${PUBLIC_BRANCH}"
-git push "${PUBLIC_REMOTE}" "${PUBLIC_BRANCH}:${BRANCH}"
 
-info "Pushing refs to ${PUBLIC_REMOTE}..."
+info "Pushing refs to private repository..."
 TMP_EXISTING_REFS_FILE=$(mktemp)
 git ls-remote "${PRIVATE_REMOTE}" | cut -f 2 | grep "^${REF_TREE_ROOT}/" > ${TMP_EXISTING_REFS_FILE} || true
-
 for ref in $(git for-each-ref "${REF_TREE_ROOT}" | cut -f 2 | grep -v --file="${TMP_EXISTING_REFS_FILE}"); do
   echo "committing ref $ref"
   git push "${PRIVATE_REMOTE}" "${ref}"
 done
+
+info "Pushing ${BRANCH} to public repository..."
+git push "${PUBLIC_REMOTE}" "${PUBLIC_BRANCH}:${BRANCH}"
 
 info "done"


### PR DESCRIPTION
More context: https://sonarsource.slack.com/archives/CMW13GWSC/p1655915197676689

This should make the script a bit more robust in case the public repo push fails. The modification makes sure that we update the private repo first and then deal with the public one.

If this makes sense to you, maybe it should be replicated on this repository master branch?